### PR TITLE
Render stl models with Qt3D

### DIFF
--- a/Process3DImage.pro
+++ b/Process3DImage.pro
@@ -1,78 +1,21 @@
-QT       += core gui opengl widgets openglwidgets 3dcore 3drender 3dextras 3dinput
+QT       += core gui widgets 3dcore 3drender 3dextras 3dinput
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
-CONFIG += c++17 opengl
-QMAKE_PROJECT_DEPTH = 0
-
-# You can make your code fail to compile if it uses deprecated APIs.
-# In order to do so, uncomment the following line.
-#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+CONFIG += c++17
 
 SOURCES += \
-    Process3DWidget.cpp \
     ProcessModelWithQt3D.cpp \
-    main.cpp \
-    mainwindow.cpp
+    main.cpp
 
 HEADERS += \
-    Process3DWidget.h \
-    ProcessModelWithQt3D.h \
-    mainwindow.h
+    ProcessModelWithQt3D.h
 
 FORMS += \
-    Process3DWidget.ui \
     ProcessModelWithQt3D.ui
 
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin
 else: unix:!android: target.path = /opt/$${TARGET}/bin
 !isEmpty(target.path): INSTALLS += target
-
-# 根据构建类型选择VTK路径
-CONFIG(debug, debug|release) {
-    VTK_DIR = "D:/QtProject/Process3DImage/VTK-9.5.0/VTK_debug"
-} else {
-    VTK_DIR = "D:/QtProject/Process3DImage/VTK-9.5.0/VTK_release"
-}
-
-# 包含路径
-INCLUDEPATH += $${VTK_DIR}/include/vtk-9.5
-
-# 库路径
-LIBS += -L$${VTK_DIR}/lib
-
-# 链接必要的VTK库
-debug {
-    LIBS += -lvtkCommonCore-9.5d
-    LIBS += -lvtkCommonDataModel-9.5d
-    LIBS += -lvtkCommonExecutionModel-9.5d
-    LIBS += -lvtkFiltersCore-9.5d
-    LIBS += -lvtkFiltersSources-9.5d
-    LIBS += -lvtkGUISupportQt-9.5d
-    LIBS += -lvtkIOGeometry-9.5d
-    LIBS += -lvtkInteractionStyle-9.5d
-    LIBS += -lvtkRenderingCore-9.5d
-    LIBS += -lvtkRenderingOpenGL2-9.5d
-    LIBS += -lvtksys-9.5d
-    LIBS += -lvtkCommonTransforms-9.5d
-    LIBS += -lvtkImagingCore-9.5d
-    LIBS += -lvtkImagingSources-9.5d
-}
-else {
-    LIBS += -lvtkCommonCore-9.5
-    LIBS += -lvtkCommonDataModel-9.5
-    LIBS += -lvtkCommonExecutionModel-9.5
-    LIBS += -lvtkFiltersCore-9.5
-    LIBS += -lvtkFiltersSources-9.5
-    LIBS += -lvtkGUISupportQt-9.5
-    LIBS += -lvtkIOGeometry-9.5
-    LIBS += -lvtkInteractionStyle-9.5
-    LIBS += -lvtkRenderingCore-9.5
-    LIBS += -lvtkRenderingOpenGL2-9.5
-    LIBS += -lvtksys-9.5
-    LIBS += -lvtkCommonTransforms-9.5
-    LIBS += -lvtkImagingCore-9.5
-    LIBS += -lvtkImagingSources-9.5
-}
 

--- a/ProcessModelWithQt3D.cpp
+++ b/ProcessModelWithQt3D.cpp
@@ -4,9 +4,13 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QVBoxLayout>
+#include <QDebug>
 #include <Qt3DExtras/QPhongMaterial>
 #include <Qt3DRender/QPointLight>
 #include <Qt3DExtras/QForwardRenderer>
+#include <Qt3DRender/QCameraLens>
+#include <Qt3DCore/QTransform>
+#include <QColor>
 
 
 ProcessModelWithQt3D::ProcessModelWithQt3D(QWidget *parent)
@@ -32,8 +36,17 @@ ProcessModelWithQt3D::~ProcessModelWithQt3D()
 
 void ProcessModelWithQt3D::setup3DScene()
 {
+    // 确保容器有布局
+    if (!ui->model3DViewContainer->layout()) {
+        auto *layout = new QVBoxLayout(ui->model3DViewContainer);
+        layout->setContentsMargins(0, 0, 0, 0);
+        layout->setSpacing(0);
+    }
+
     // 创建3D窗口容器
-    QWidget *container = QWidget::createWindowContainer(new Qt3DExtras::Qt3DWindow(), this);
+    QWidget *container = QWidget::createWindowContainer(new Qt3DExtras::Qt3DWindow(), ui->model3DViewContainer);
+    container->setFocusPolicy(Qt::StrongFocus);
+
     ui->model3DViewContainer->layout()->addWidget(container);
     m_3dWindow = qobject_cast<Qt3DExtras::Qt3DWindow*>(container->window());
 
@@ -62,6 +75,11 @@ void ProcessModelWithQt3D::setup3DScene()
     m_camController->setLinearSpeed(50.0f);
     m_camController->setLookSpeed(180.0f);
 
+    // 背景色
+    if (auto *renderer = m_3dWindow->defaultFrameGraph()) {
+        renderer->setClearColor(QColor(0x20, 0x20, 0x20));
+    }
+
     // 设置场景
     m_3dWindow->setRootEntity(m_rootEntity);
 }
@@ -72,6 +90,7 @@ void ProcessModelWithQt3D::loadSTLModel(const QString& filePath)
     if (m_modelEntity) {
         m_modelEntity->deleteLater();
         m_modelEntity = nullptr;
+        m_modelTransform = nullptr;
     }
 
     // 创建新模型实体
@@ -85,9 +104,13 @@ void ProcessModelWithQt3D::loadSTLModel(const QString& filePath)
     auto *material = new Qt3DExtras::QPhongMaterial(m_modelEntity);
     material->setDiffuse(QColor(QRgb(0x928327)));
 
+    // 变换
+    m_modelTransform = new Qt3DCore::QTransform(m_modelEntity);
+
     // 添加到实体
     m_modelEntity->addComponent(sceneLoader);
     m_modelEntity->addComponent(material);
+    m_modelEntity->addComponent(m_modelTransform);
 
     // 重置相机位置
     m_camera->setPosition(QVector3D(0, 0, 40.0f));
@@ -108,29 +131,35 @@ void ProcessModelWithQt3D::on_load3DModelBtn_clicked()
 
 void ProcessModelWithQt3D::on_directionComboBox_currentIndexChanged(int index)
 {
-    // // 根据选择的方向调整模型
-    // if (!m_modelEntity) return;
+    if (!m_modelTransform) return;
 
-    // auto *transform = m_modelEntity->component<Qt3DCore::QTransform>();
-    // if (!transform) {
-    //     transform = new Qt3DCore::QTransform(m_modelEntity);
-    //     m_modelEntity->addComponent(transform);
-    // }
-
-    // switch (index) {
-    // case 0: // 默认方向
-    //     transform->setRotation(QQuaternion());
-    //     break;
-    // case 1: // X轴旋转90°
-    //     transform->setRotation(QQuaternion::fromAxisAndAngle(QVector3D(1, 0, 0), 90));
-    //     break;
-    // case 2: // Y轴旋转90°
-    //     transform->setRotation(QQuaternion::fromAxisAndAngle(QVector3D(0, 1, 0), 90));
-    //     break;
-    // case 3: // Z轴旋转90°
-    //     transform->setRotation(QQuaternion::fromAxisAndAngle(QVector3D(0, 0, 1), 90));
-    //     break;
-    // }
+    // 根据选择的方向调整模型朝向
+    QQuaternion rotation;
+    switch (index) {
+    case 0: // +X
+        rotation = QQuaternion::fromAxisAndAngle(QVector3D(0, 1, 0), -90.0f);
+        break;
+    case 1: // -X
+        rotation = QQuaternion::fromAxisAndAngle(QVector3D(0, 1, 0), 90.0f);
+        break;
+    case 2: // +Y
+        rotation = QQuaternion::fromAxisAndAngle(QVector3D(1, 0, 0), 90.0f);
+        break;
+    case 3: // -Y
+        rotation = QQuaternion::fromAxisAndAngle(QVector3D(1, 0, 0), -90.0f);
+        break;
+    case 4: // +Z
+        rotation = QQuaternion();
+        break;
+    case 5: // -Z
+        rotation = QQuaternion::fromAxisAndAngle(QVector3D(0, 1, 0), 180.0f);
+        break;
+    case 6: // Origin (重置)
+    default:
+        rotation = QQuaternion();
+        break;
+    }
+    m_modelTransform->setRotation(rotation);
 }
 
 void ProcessModelWithQt3D::on_createGrayImage_clicked()

--- a/ProcessModelWithQt3D.h
+++ b/ProcessModelWithQt3D.h
@@ -8,7 +8,8 @@
 #include <Qt3DExtras/Qt3DWindow>
 #include <Qt3DRender/QSceneLoader>
 #include <QUrl>
-
+#include <Qt3DCore/QTransform>
+#include <QImage>
 
 
 namespace Ui {
@@ -47,6 +48,9 @@ private:
     void loadSTLModel(const QString& filePath);
 
     QImage grayImage; // 存储生成的灰度图
+
+    // 模型的变换（用于旋转/缩放/平移）
+    Qt3DCore::QTransform *m_modelTransform = nullptr;
 };
 
 #endif // PROCESSMODELWITHQT3D_H

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,3 @@
-#include "mainwindow.h"
-#include "Process3DWidget.h"
 #include "ProcessModelWithQt3D.h"
 #include <QApplication>
 
@@ -7,11 +5,6 @@ int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
 
-    // 确保VTK使用正确的OpenGL后端
-    QSurfaceFormat::setDefaultFormat(QVTKOpenGLNativeWidget::defaultFormat());
-
-    //MainWindow w;
-    //Process3DWidget w;
     ProcessModelWithQt3D w;
     w.show();
     return a.exec();


### PR DESCRIPTION
Implement STL model rendering in `model3DviewContainer` using Qt3D, removing external VTK dependencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-298ad42e-9c35-48ea-90b3-b26f09c8dd36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-298ad42e-9c35-48ea-90b3-b26f09c8dd36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

